### PR TITLE
Add ReadRaw and WriteRaw to DAQ API

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -165,6 +165,7 @@ service NiDAQmx {
   rpc ReadDigitalU16(ReadDigitalU16Request) returns (ReadDigitalU16Response);
   rpc ReadDigitalU32(ReadDigitalU32Request) returns (ReadDigitalU32Response);
   rpc ReadDigitalU8(ReadDigitalU8Request) returns (ReadDigitalU8Response);
+  rpc ReadRaw(ReadRawRequest) returns (ReadRawResponse);
   rpc RegisterDoneEvent(RegisterDoneEventRequest) returns (stream RegisterDoneEventResponse);
   rpc ReserveNetworkDevice(ReserveNetworkDeviceRequest) returns (ReserveNetworkDeviceResponse);
   rpc ResetDevice(ResetDeviceRequest) returns (ResetDeviceResponse);
@@ -196,6 +197,7 @@ service NiDAQmx {
   rpc WriteDigitalU16(WriteDigitalU16Request) returns (WriteDigitalU16Response);
   rpc WriteDigitalU32(WriteDigitalU32Request) returns (WriteDigitalU32Response);
   rpc WriteDigitalU8(WriteDigitalU8Request) returns (WriteDigitalU8Response);
+  rpc WriteRaw(WriteRawRequest) returns (WriteRawResponse);
 }
 
 enum NiDAQmxAttributes {
@@ -3683,6 +3685,20 @@ message ReadDigitalU8Response {
   int32 samps_per_chan_read = 3;
 }
 
+message ReadRawRequest {
+  nidevice_grpc.Session task = 1;
+  int32 num_samps_per_chan = 2;
+  double timeout = 3;
+  uint32 array_size_in_bytes = 4;
+}
+
+message ReadRawResponse {
+  int32 status = 1;
+  bytes read_array = 2;
+  int32 samps_read = 3;
+  int32 num_bytes_per_samp = 4;
+}
+
 message RegisterDoneEventRequest {
   nidevice_grpc.Session task = 1;
   uint32 options = 2;
@@ -4080,6 +4096,19 @@ message WriteDigitalU8Request {
 }
 
 message WriteDigitalU8Response {
+  int32 status = 1;
+  int32 samps_per_chan_written = 2;
+}
+
+message WriteRawRequest {
+  nidevice_grpc.Session task = 1;
+  int32 num_samps = 2;
+  bool auto_start = 3;
+  double timeout = 4;
+  bytes write_array = 5;
+}
+
+message WriteRawResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
 }

--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -18,6 +18,7 @@ import "session.proto";
 service NiDAQmx {
   rpc AddGlobalChansToTask(AddGlobalChansToTaskRequest) returns (AddGlobalChansToTaskResponse);
   rpc AddNetworkDevice(AddNetworkDeviceRequest) returns (AddNetworkDeviceResponse);
+  rpc CalculateReversePolyCoeff(CalculateReversePolyCoeffRequest) returns (CalculateReversePolyCoeffResponse);
   rpc CfgAnlgEdgeRefTrig(CfgAnlgEdgeRefTrigRequest) returns (CfgAnlgEdgeRefTrigResponse);
   rpc CfgAnlgEdgeStartTrig(CfgAnlgEdgeStartTrigRequest) returns (CfgAnlgEdgeStartTrigResponse);
   rpc CfgAnlgMultiEdgeRefTrig(CfgAnlgMultiEdgeRefTrigRequest) returns (CfgAnlgMultiEdgeRefTrigResponse);
@@ -777,6 +778,20 @@ message AddNetworkDeviceRequest {
 message AddNetworkDeviceResponse {
   int32 status = 1;
   string device_name_out = 2;
+}
+
+message CalculateReversePolyCoeffRequest {
+  repeated double forward_coeffs = 1;
+  uint32 num_forward_coeffs_in = 2;
+  double min_val_x = 3;
+  double max_val_x = 4;
+  int32 num_points_to_compute = 5;
+  int32 reverse_poly_order = 6;
+}
+
+message CalculateReversePolyCoeffResponse {
+  int32 status = 1;
+  repeated double reverse_coeffs = 2;
 }
 
 message CfgAnlgEdgeRefTrigRequest {

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -170,6 +170,7 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.ReadDigitalU16 = reinterpret_cast<ReadDigitalU16Ptr>(shared_library_.get_function_pointer("DAQmxReadDigitalU16"));
   function_pointers_.ReadDigitalU32 = reinterpret_cast<ReadDigitalU32Ptr>(shared_library_.get_function_pointer("DAQmxReadDigitalU32"));
   function_pointers_.ReadDigitalU8 = reinterpret_cast<ReadDigitalU8Ptr>(shared_library_.get_function_pointer("DAQmxReadDigitalU8"));
+  function_pointers_.ReadRaw = reinterpret_cast<ReadRawPtr>(shared_library_.get_function_pointer("DAQmxReadRaw"));
   function_pointers_.RegisterDoneEvent = reinterpret_cast<RegisterDoneEventPtr>(shared_library_.get_function_pointer("DAQmxRegisterDoneEvent"));
   function_pointers_.ReserveNetworkDevice = reinterpret_cast<ReserveNetworkDevicePtr>(shared_library_.get_function_pointer("DAQmxReserveNetworkDevice"));
   function_pointers_.ResetDevice = reinterpret_cast<ResetDevicePtr>(shared_library_.get_function_pointer("DAQmxResetDevice"));
@@ -201,6 +202,7 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.WriteDigitalU16 = reinterpret_cast<WriteDigitalU16Ptr>(shared_library_.get_function_pointer("DAQmxWriteDigitalU16"));
   function_pointers_.WriteDigitalU32 = reinterpret_cast<WriteDigitalU32Ptr>(shared_library_.get_function_pointer("DAQmxWriteDigitalU32"));
   function_pointers_.WriteDigitalU8 = reinterpret_cast<WriteDigitalU8Ptr>(shared_library_.get_function_pointer("DAQmxWriteDigitalU8"));
+  function_pointers_.WriteRaw = reinterpret_cast<WriteRawPtr>(shared_library_.get_function_pointer("DAQmxWriteRaw"));
 }
 
 NiDAQmxLibrary::~NiDAQmxLibrary()
@@ -2002,6 +2004,18 @@ int32 NiDAQmxLibrary::ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, floa
 #endif
 }
 
+int32 NiDAQmxLibrary::ReadRaw(TaskHandle task, int32 numSampsPerChan, float64 timeout, uInt8 readArray[], uInt32 arraySizeInBytes, int32* sampsRead, int32* numBytesPerSamp, bool32* reserved)
+{
+  if (!function_pointers_.ReadRaw) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxReadRaw.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxReadRaw(task, numSampsPerChan, timeout, readArray, arraySizeInBytes, sampsRead, numBytesPerSamp, reserved);
+#else
+  return function_pointers_.ReadRaw(task, numSampsPerChan, timeout, readArray, arraySizeInBytes, sampsRead, numBytesPerSamp, reserved);
+#endif
+}
+
 int32 NiDAQmxLibrary::RegisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData)
 {
   if (!function_pointers_.RegisterDoneEvent) {
@@ -2371,6 +2385,18 @@ int32 NiDAQmxLibrary::WriteDigitalU8(TaskHandle task, int32 numSampsPerChan, boo
   return DAQmxWriteDigitalU8(task, numSampsPerChan, autoStart, timeout, dataLayout, writeArray, sampsPerChanWritten, reserved);
 #else
   return function_pointers_.WriteDigitalU8(task, numSampsPerChan, autoStart, timeout, dataLayout, writeArray, sampsPerChanWritten, reserved);
+#endif
+}
+
+int32 NiDAQmxLibrary::WriteRaw(TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved)
+{
+  if (!function_pointers_.WriteRaw) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxWriteRaw.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxWriteRaw(task, numSamps, autoStart, timeout, writeArray, sampsPerChanWritten, reserved);
+#else
+  return function_pointers_.WriteRaw(task, numSamps, autoStart, timeout, writeArray, sampsPerChanWritten, reserved);
 #endif
 }
 

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -23,6 +23,7 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   }
   function_pointers_.AddGlobalChansToTask = reinterpret_cast<AddGlobalChansToTaskPtr>(shared_library_.get_function_pointer("DAQmxAddGlobalChansToTask"));
   function_pointers_.AddNetworkDevice = reinterpret_cast<AddNetworkDevicePtr>(shared_library_.get_function_pointer("DAQmxAddNetworkDevice"));
+  function_pointers_.CalculateReversePolyCoeff = reinterpret_cast<CalculateReversePolyCoeffPtr>(shared_library_.get_function_pointer("DAQmxCalculateReversePolyCoeff"));
   function_pointers_.CfgAnlgEdgeRefTrig = reinterpret_cast<CfgAnlgEdgeRefTrigPtr>(shared_library_.get_function_pointer("DAQmxCfgAnlgEdgeRefTrig"));
   function_pointers_.CfgAnlgEdgeStartTrig = reinterpret_cast<CfgAnlgEdgeStartTrigPtr>(shared_library_.get_function_pointer("DAQmxCfgAnlgEdgeStartTrig"));
   function_pointers_.CfgAnlgMultiEdgeRefTrig = reinterpret_cast<CfgAnlgMultiEdgeRefTrigPtr>(shared_library_.get_function_pointer("DAQmxCfgAnlgMultiEdgeRefTrig"));
@@ -234,6 +235,18 @@ int32 NiDAQmxLibrary::AddNetworkDevice(const char ipAddress[], const char device
   return DAQmxAddNetworkDevice(ipAddress, deviceName, attemptReservation, timeout, deviceNameOut, deviceNameOutBufferSize);
 #else
   return function_pointers_.AddNetworkDevice(ipAddress, deviceName, attemptReservation, timeout, deviceNameOut, deviceNameOutBufferSize);
+#endif
+}
+
+int32 NiDAQmxLibrary::CalculateReversePolyCoeff(const float64 forwardCoeffs[], uInt32 numForwardCoeffsIn, float64 minValX, float64 maxValX, int32 numPointsToCompute, int32 reversePolyOrder, float64 reverseCoeffs[])
+{
+  if (!function_pointers_.CalculateReversePolyCoeff) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxCalculateReversePolyCoeff.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxCalculateReversePolyCoeff(forwardCoeffs, numForwardCoeffsIn, minValX, maxValX, numPointsToCompute, reversePolyOrder, reverseCoeffs);
+#else
+  return function_pointers_.CalculateReversePolyCoeff(forwardCoeffs, numForwardCoeffsIn, minValX, maxValX, numPointsToCompute, reversePolyOrder, reverseCoeffs);
 #endif
 }
 

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -20,6 +20,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   ::grpc::Status check_function_exists(std::string functionName);
   int32 AddGlobalChansToTask(TaskHandle task, const char channelNames[]);
   int32 AddNetworkDevice(const char ipAddress[], const char deviceName[], bool32 attemptReservation, float64 timeout, char deviceNameOut[], uInt32 deviceNameOutBufferSize);
+  int32 CalculateReversePolyCoeff(const float64 forwardCoeffs[], uInt32 numForwardCoeffsIn, float64 minValX, float64 maxValX, int32 numPointsToCompute, int32 reversePolyOrder, float64 reverseCoeffs[]);
   int32 CfgAnlgEdgeRefTrig(TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel, uInt32 pretriggerSamples);
   int32 CfgAnlgEdgeStartTrig(TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel);
   int32 CfgAnlgMultiEdgeRefTrig(TaskHandle task, const char triggerSources[], int32 triggerSlopeArray[], const float64 triggerLevelArray[], uInt32 pretriggerSamples, uInt32 arraySize);
@@ -201,6 +202,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
  private:
   using AddGlobalChansToTaskPtr = int32 (*)(TaskHandle task, const char channelNames[]);
   using AddNetworkDevicePtr = int32 (*)(const char ipAddress[], const char deviceName[], bool32 attemptReservation, float64 timeout, char deviceNameOut[], uInt32 deviceNameOutBufferSize);
+  using CalculateReversePolyCoeffPtr = int32 (*)(const float64 forwardCoeffs[], uInt32 numForwardCoeffsIn, float64 minValX, float64 maxValX, int32 numPointsToCompute, int32 reversePolyOrder, float64 reverseCoeffs[]);
   using CfgAnlgEdgeRefTrigPtr = int32 (*)(TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel, uInt32 pretriggerSamples);
   using CfgAnlgEdgeStartTrigPtr = int32 (*)(TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel);
   using CfgAnlgMultiEdgeRefTrigPtr = int32 (*)(TaskHandle task, const char triggerSources[], int32 triggerSlopeArray[], const float64 triggerLevelArray[], uInt32 pretriggerSamples, uInt32 arraySize);
@@ -382,6 +384,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   typedef struct FunctionPointers {
     AddGlobalChansToTaskPtr AddGlobalChansToTask;
     AddNetworkDevicePtr AddNetworkDevice;
+    CalculateReversePolyCoeffPtr CalculateReversePolyCoeff;
     CfgAnlgEdgeRefTrigPtr CfgAnlgEdgeRefTrig;
     CfgAnlgEdgeStartTrigPtr CfgAnlgEdgeStartTrig;
     CfgAnlgMultiEdgeRefTrigPtr CfgAnlgMultiEdgeRefTrig;

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -167,6 +167,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   int32 ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   int32 ReadDigitalU32(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt32 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
+  int32 ReadRaw(TaskHandle task, int32 numSampsPerChan, float64 timeout, uInt8 readArray[], uInt32 arraySizeInBytes, int32* sampsRead, int32* numBytesPerSamp, bool32* reserved);
   int32 RegisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData);
   int32 ReserveNetworkDevice(const char deviceName[], bool32 overrideReservation);
   int32 ResetDevice(const char deviceName[]);
@@ -198,6 +199,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   int32 WriteDigitalU32(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt32 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   int32 WriteDigitalU8(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
+  int32 WriteRaw(TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
 
  private:
   using AddGlobalChansToTaskPtr = int32 (*)(TaskHandle task, const char channelNames[]);
@@ -349,6 +351,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   using ReadDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   using ReadDigitalU32Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt32 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   using ReadDigitalU8Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
+  using ReadRawPtr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, uInt8 readArray[], uInt32 arraySizeInBytes, int32* sampsRead, int32* numBytesPerSamp, bool32* reserved);
   using RegisterDoneEventPtr = int32 (*)(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData);
   using ReserveNetworkDevicePtr = int32 (*)(const char deviceName[], bool32 overrideReservation);
   using ResetDevicePtr = int32 (*)(const char deviceName[]);
@@ -380,6 +383,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   using WriteDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   using WriteDigitalU32Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt32 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   using WriteDigitalU8Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
+  using WriteRawPtr = int32 (*)(TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
 
   typedef struct FunctionPointers {
     AddGlobalChansToTaskPtr AddGlobalChansToTask;
@@ -531,6 +535,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
     ReadDigitalU16Ptr ReadDigitalU16;
     ReadDigitalU32Ptr ReadDigitalU32;
     ReadDigitalU8Ptr ReadDigitalU8;
+    ReadRawPtr ReadRaw;
     RegisterDoneEventPtr RegisterDoneEvent;
     ReserveNetworkDevicePtr ReserveNetworkDevice;
     ResetDevicePtr ResetDevice;
@@ -562,6 +567,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
     WriteDigitalU16Ptr WriteDigitalU16;
     WriteDigitalU32Ptr WriteDigitalU32;
     WriteDigitalU8Ptr WriteDigitalU8;
+    WriteRawPtr WriteRaw;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -17,6 +17,7 @@ class NiDAQmxLibraryInterface {
 
   virtual int32 AddGlobalChansToTask(TaskHandle task, const char channelNames[]) = 0;
   virtual int32 AddNetworkDevice(const char ipAddress[], const char deviceName[], bool32 attemptReservation, float64 timeout, char deviceNameOut[], uInt32 deviceNameOutBufferSize) = 0;
+  virtual int32 CalculateReversePolyCoeff(const float64 forwardCoeffs[], uInt32 numForwardCoeffsIn, float64 minValX, float64 maxValX, int32 numPointsToCompute, int32 reversePolyOrder, float64 reverseCoeffs[]) = 0;
   virtual int32 CfgAnlgEdgeRefTrig(TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel, uInt32 pretriggerSamples) = 0;
   virtual int32 CfgAnlgEdgeStartTrig(TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel) = 0;
   virtual int32 CfgAnlgMultiEdgeRefTrig(TaskHandle task, const char triggerSources[], int32 triggerSlopeArray[], const float64 triggerLevelArray[], uInt32 pretriggerSamples, uInt32 arraySize) = 0;

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -164,6 +164,7 @@ class NiDAQmxLibraryInterface {
   virtual int32 ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 ReadDigitalU32(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt32 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
+  virtual int32 ReadRaw(TaskHandle task, int32 numSampsPerChan, float64 timeout, uInt8 readArray[], uInt32 arraySizeInBytes, int32* sampsRead, int32* numBytesPerSamp, bool32* reserved) = 0;
   virtual int32 RegisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData) = 0;
   virtual int32 ReserveNetworkDevice(const char deviceName[], bool32 overrideReservation) = 0;
   virtual int32 ResetDevice(const char deviceName[]) = 0;
@@ -195,6 +196,7 @@ class NiDAQmxLibraryInterface {
   virtual int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
   virtual int32 WriteDigitalU32(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt32 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
   virtual int32 WriteDigitalU8(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
+  virtual int32 WriteRaw(TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
 };
 
 }  // namespace nidaqmx_grpc

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -166,6 +166,7 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, ReadDigitalU16, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, ReadDigitalU32, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt32 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, ReadDigitalU8, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
+  MOCK_METHOD(int32, ReadRaw, (TaskHandle task, int32 numSampsPerChan, float64 timeout, uInt8 readArray[], uInt32 arraySizeInBytes, int32* sampsRead, int32* numBytesPerSamp, bool32* reserved), (override));
   MOCK_METHOD(int32, RegisterDoneEvent, (TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData), (override));
   MOCK_METHOD(int32, ReserveNetworkDevice, (const char deviceName[], bool32 overrideReservation), (override));
   MOCK_METHOD(int32, ResetDevice, (const char deviceName[]), (override));
@@ -197,6 +198,7 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, WriteDigitalU16, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
   MOCK_METHOD(int32, WriteDigitalU32, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt32 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
   MOCK_METHOD(int32, WriteDigitalU8, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
+  MOCK_METHOD(int32, WriteRaw, (TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
 };
 
 }  // namespace unit

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -19,6 +19,7 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
  public:
   MOCK_METHOD(int32, AddGlobalChansToTask, (TaskHandle task, const char channelNames[]), (override));
   MOCK_METHOD(int32, AddNetworkDevice, (const char ipAddress[], const char deviceName[], bool32 attemptReservation, float64 timeout, char deviceNameOut[], uInt32 deviceNameOutBufferSize), (override));
+  MOCK_METHOD(int32, CalculateReversePolyCoeff, (const float64 forwardCoeffs[], uInt32 numForwardCoeffsIn, float64 minValX, float64 maxValX, int32 numPointsToCompute, int32 reversePolyOrder, float64 reverseCoeffs[]), (override));
   MOCK_METHOD(int32, CfgAnlgEdgeRefTrig, (TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel, uInt32 pretriggerSamples), (override));
   MOCK_METHOD(int32, CfgAnlgEdgeStartTrig, (TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel), (override));
   MOCK_METHOD(int32, CfgAnlgMultiEdgeRefTrig, (TaskHandle task, const char triggerSources[], int32 triggerSlopeArray[], const float64 triggerLevelArray[], uInt32 pretriggerSamples, uInt32 arraySize), (override));

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -74,6 +74,33 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::CalculateReversePolyCoeff(::grpc::ServerContext* context, const CalculateReversePolyCoeffRequest* request, CalculateReversePolyCoeffResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto forward_coeffs = const_cast<const float64*>(request->forward_coeffs().data());
+      uInt32 num_forward_coeffs_in = request->num_forward_coeffs_in();
+      float64 min_val_x = request->min_val_x();
+      float64 max_val_x = request->max_val_x();
+      int32 num_points_to_compute = request->num_points_to_compute();
+      int32 reverse_poly_order = request->reverse_poly_order();
+      response->mutable_reverse_coeffs()->Resize((reverse_poly_order < 0) ? num_forward_coeffs_in : reverse_poly_order + 1, 0);
+      float64* reverse_coeffs = response->mutable_reverse_coeffs()->mutable_data();
+      auto status = library_->CalculateReversePolyCoeff(forward_coeffs, num_forward_coeffs_in, min_val_x, max_val_x, num_points_to_compute, reverse_poly_order, reverse_coeffs);
+      response->set_status(status);
+      if (status == 0) {
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::CfgAnlgEdgeRefTrig(::grpc::ServerContext* context, const CfgAnlgEdgeRefTrigRequest* request, CfgAnlgEdgeRefTrigResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -30,6 +30,7 @@ public:
   
   ::grpc::Status AddGlobalChansToTask(::grpc::ServerContext* context, const AddGlobalChansToTaskRequest* request, AddGlobalChansToTaskResponse* response) override;
   ::grpc::Status AddNetworkDevice(::grpc::ServerContext* context, const AddNetworkDeviceRequest* request, AddNetworkDeviceResponse* response) override;
+  ::grpc::Status CalculateReversePolyCoeff(::grpc::ServerContext* context, const CalculateReversePolyCoeffRequest* request, CalculateReversePolyCoeffResponse* response) override;
   ::grpc::Status CfgAnlgEdgeRefTrig(::grpc::ServerContext* context, const CfgAnlgEdgeRefTrigRequest* request, CfgAnlgEdgeRefTrigResponse* response) override;
   ::grpc::Status CfgAnlgEdgeStartTrig(::grpc::ServerContext* context, const CfgAnlgEdgeStartTrigRequest* request, CfgAnlgEdgeStartTrigResponse* response) override;
   ::grpc::Status CfgAnlgMultiEdgeRefTrig(::grpc::ServerContext* context, const CfgAnlgMultiEdgeRefTrigRequest* request, CfgAnlgMultiEdgeRefTrigResponse* response) override;

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -177,6 +177,7 @@ public:
   ::grpc::Status ReadDigitalU16(::grpc::ServerContext* context, const ReadDigitalU16Request* request, ReadDigitalU16Response* response) override;
   ::grpc::Status ReadDigitalU32(::grpc::ServerContext* context, const ReadDigitalU32Request* request, ReadDigitalU32Response* response) override;
   ::grpc::Status ReadDigitalU8(::grpc::ServerContext* context, const ReadDigitalU8Request* request, ReadDigitalU8Response* response) override;
+  ::grpc::Status ReadRaw(::grpc::ServerContext* context, const ReadRawRequest* request, ReadRawResponse* response) override;
   ::grpc::Status RegisterDoneEvent(::grpc::ServerContext* context, const RegisterDoneEventRequest* request, ::grpc::ServerWriter<RegisterDoneEventResponse>* writer) override;
   ::grpc::Status ReserveNetworkDevice(::grpc::ServerContext* context, const ReserveNetworkDeviceRequest* request, ReserveNetworkDeviceResponse* response) override;
   ::grpc::Status ResetDevice(::grpc::ServerContext* context, const ResetDeviceRequest* request, ResetDeviceResponse* response) override;
@@ -208,6 +209,7 @@ public:
   ::grpc::Status WriteDigitalU16(::grpc::ServerContext* context, const WriteDigitalU16Request* request, WriteDigitalU16Response* response) override;
   ::grpc::Status WriteDigitalU32(::grpc::ServerContext* context, const WriteDigitalU32Request* request, WriteDigitalU32Response* response) override;
   ::grpc::Status WriteDigitalU8(::grpc::ServerContext* context, const WriteDigitalU8Request* request, WriteDigitalU8Response* response) override;
+  ::grpc::Status WriteRaw(::grpc::ServerContext* context, const WriteRawRequest* request, WriteRawResponse* response) override;
 private:
   NiDAQmxLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;

--- a/generated/nifake_non_ivi/nifake_non_ivi.proto
+++ b/generated/nifake_non_ivi/nifake_non_ivi.proto
@@ -20,6 +20,7 @@ service NiFakeNonIvi {
   rpc Init(InitRequest) returns (InitResponse);
   rpc InitWithHandleNameAsSessionName(InitWithHandleNameAsSessionNameRequest) returns (InitWithHandleNameAsSessionNameResponse);
   rpc InputArraysWithNarrowIntegerTypes(InputArraysWithNarrowIntegerTypesRequest) returns (InputArraysWithNarrowIntegerTypesResponse);
+  rpc IotaWithCustomSize(IotaWithCustomSizeRequest) returns (IotaWithCustomSizeResponse);
   rpc OutputArraysWithNarrowIntegerTypes(OutputArraysWithNarrowIntegerTypesRequest) returns (OutputArraysWithNarrowIntegerTypesResponse);
   rpc InputArrayOfBytes(InputArrayOfBytesRequest) returns (InputArrayOfBytesResponse);
   rpc OutputArrayOfBytes(OutputArrayOfBytesRequest) returns (OutputArrayOfBytesResponse);
@@ -64,6 +65,16 @@ message InputArraysWithNarrowIntegerTypesRequest {
 
 message InputArraysWithNarrowIntegerTypesResponse {
   int32 status = 1;
+}
+
+message IotaWithCustomSizeRequest {
+  int32 size_one = 1;
+  int32 size_two = 2;
+}
+
+message IotaWithCustomSizeResponse {
+  int32 status = 1;
+  repeated int32 data = 2;
 }
 
 message OutputArraysWithNarrowIntegerTypesRequest {

--- a/generated/nifake_non_ivi/nifake_non_ivi_library.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library.cpp
@@ -25,6 +25,7 @@ NiFakeNonIviLibrary::NiFakeNonIviLibrary() : shared_library_(kLibraryName)
   function_pointers_.Init = reinterpret_cast<InitPtr>(shared_library_.get_function_pointer("niFakeNonIvi_Init"));
   function_pointers_.InitWithHandleNameAsSessionName = reinterpret_cast<InitWithHandleNameAsSessionNamePtr>(shared_library_.get_function_pointer("niFakeNonIvi_InitWithHandleNameAsSessionName"));
   function_pointers_.InputArraysWithNarrowIntegerTypes = reinterpret_cast<InputArraysWithNarrowIntegerTypesPtr>(shared_library_.get_function_pointer("niFakeNonIvi_InputArraysWithNarrowIntegerTypes"));
+  function_pointers_.IotaWithCustomSize = reinterpret_cast<IotaWithCustomSizePtr>(shared_library_.get_function_pointer("niFakeNonIvi_IotaWithCustomSize"));
   function_pointers_.OutputArraysWithNarrowIntegerTypes = reinterpret_cast<OutputArraysWithNarrowIntegerTypesPtr>(shared_library_.get_function_pointer("niFakeNonIvi_OutputArraysWithNarrowIntegerTypes"));
   function_pointers_.InputArrayOfBytes = reinterpret_cast<InputArrayOfBytesPtr>(shared_library_.get_function_pointer("niFakeNonIvi_InputArrayOfBytes"));
   function_pointers_.OutputArrayOfBytes = reinterpret_cast<OutputArrayOfBytesPtr>(shared_library_.get_function_pointer("niFakeNonIvi_OutputArrayOfBytes"));
@@ -87,6 +88,18 @@ int32 NiFakeNonIviLibrary::InputArraysWithNarrowIntegerTypes(const myUInt16 u16A
   return niFakeNonIvi_InputArraysWithNarrowIntegerTypes(u16Array, i16Array, i8Array);
 #else
   return function_pointers_.InputArraysWithNarrowIntegerTypes(u16Array, i16Array, i8Array);
+#endif
+}
+
+int32 NiFakeNonIviLibrary::IotaWithCustomSize(int32 sizeOne, int32 sizeTwo, int32 data[])
+{
+  if (!function_pointers_.IotaWithCustomSize) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFakeNonIvi_IotaWithCustomSize.");
+  }
+#if defined(_MSC_VER)
+  return niFakeNonIvi_IotaWithCustomSize(sizeOne, sizeTwo, data);
+#else
+  return function_pointers_.IotaWithCustomSize(sizeOne, sizeTwo, data);
 #endif
 }
 

--- a/generated/nifake_non_ivi/nifake_non_ivi_library.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library.h
@@ -22,6 +22,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
   int32 Init(const char sessionName[], FakeHandle* handle);
   int32 InitWithHandleNameAsSessionName(const char handleName[], FakeHandle* handle);
   int32 InputArraysWithNarrowIntegerTypes(const myUInt16 u16Array[], const myInt16 i16Array[], const myInt8 i8Array[]);
+  int32 IotaWithCustomSize(int32 sizeOne, int32 sizeTwo, int32 data[]);
   int32 OutputArraysWithNarrowIntegerTypes(int32 numberOfU16Samples, myUInt16 u16Data[], int32 numberOfI16Samples, myInt16 i16Data[], int32 numberOfI8Samples, myInt8 i8Data[]);
   int32 InputArrayOfBytes(const myUInt8 u8Array[]);
   int32 OutputArrayOfBytes(int32 numberOfU8Samples, myUInt8 u8Data[]);
@@ -32,6 +33,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
   using InitPtr = int32 (*)(const char sessionName[], FakeHandle* handle);
   using InitWithHandleNameAsSessionNamePtr = int32 (*)(const char handleName[], FakeHandle* handle);
   using InputArraysWithNarrowIntegerTypesPtr = int32 (*)(const myUInt16 u16Array[], const myInt16 i16Array[], const myInt8 i8Array[]);
+  using IotaWithCustomSizePtr = int32 (*)(int32 sizeOne, int32 sizeTwo, int32 data[]);
   using OutputArraysWithNarrowIntegerTypesPtr = int32 (*)(int32 numberOfU16Samples, myUInt16 u16Data[], int32 numberOfI16Samples, myInt16 i16Data[], int32 numberOfI8Samples, myInt8 i8Data[]);
   using InputArrayOfBytesPtr = int32 (*)(const myUInt8 u8Array[]);
   using OutputArrayOfBytesPtr = int32 (*)(int32 numberOfU8Samples, myUInt8 u8Data[]);
@@ -42,6 +44,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
     InitPtr Init;
     InitWithHandleNameAsSessionNamePtr InitWithHandleNameAsSessionName;
     InputArraysWithNarrowIntegerTypesPtr InputArraysWithNarrowIntegerTypes;
+    IotaWithCustomSizePtr IotaWithCustomSize;
     OutputArraysWithNarrowIntegerTypesPtr OutputArraysWithNarrowIntegerTypes;
     InputArrayOfBytesPtr InputArrayOfBytes;
     OutputArrayOfBytesPtr OutputArrayOfBytes;

--- a/generated/nifake_non_ivi/nifake_non_ivi_library_interface.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library_interface.h
@@ -19,6 +19,7 @@ class NiFakeNonIviLibraryInterface {
   virtual int32 Init(const char sessionName[], FakeHandle* handle) = 0;
   virtual int32 InitWithHandleNameAsSessionName(const char handleName[], FakeHandle* handle) = 0;
   virtual int32 InputArraysWithNarrowIntegerTypes(const myUInt16 u16Array[], const myInt16 i16Array[], const myInt8 i8Array[]) = 0;
+  virtual int32 IotaWithCustomSize(int32 sizeOne, int32 sizeTwo, int32 data[]) = 0;
   virtual int32 OutputArraysWithNarrowIntegerTypes(int32 numberOfU16Samples, myUInt16 u16Data[], int32 numberOfI16Samples, myInt16 i16Data[], int32 numberOfI8Samples, myInt8 i8Data[]) = 0;
   virtual int32 InputArrayOfBytes(const myUInt8 u8Array[]) = 0;
   virtual int32 OutputArrayOfBytes(int32 numberOfU8Samples, myUInt8 u8Data[]) = 0;

--- a/generated/nifake_non_ivi/nifake_non_ivi_mock_library.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_mock_library.h
@@ -21,6 +21,7 @@ class NiFakeNonIviMockLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryI
   MOCK_METHOD(int32, Init, (const char sessionName[], FakeHandle* handle), (override));
   MOCK_METHOD(int32, InitWithHandleNameAsSessionName, (const char handleName[], FakeHandle* handle), (override));
   MOCK_METHOD(int32, InputArraysWithNarrowIntegerTypes, (const myUInt16 u16Array[], const myInt16 i16Array[], const myInt8 i8Array[]), (override));
+  MOCK_METHOD(int32, IotaWithCustomSize, (int32 sizeOne, int32 sizeTwo, int32 data[]), (override));
   MOCK_METHOD(int32, OutputArraysWithNarrowIntegerTypes, (int32 numberOfU16Samples, myUInt16 u16Data[], int32 numberOfI16Samples, myInt16 i16Data[], int32 numberOfI8Samples, myInt8 i8Data[]), (override));
   MOCK_METHOD(int32, InputArrayOfBytes, (const myUInt8 u8Array[]), (override));
   MOCK_METHOD(int32, OutputArrayOfBytes, (int32 numberOfU8Samples, myUInt8 u8Data[]), (override));

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -179,6 +179,29 @@ namespace nifake_non_ivi_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeNonIviService::IotaWithCustomSize(::grpc::ServerContext* context, const IotaWithCustomSizeRequest* request, IotaWithCustomSizeResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      int32 size_one = request->size_one();
+      int32 size_two = request->size_two();
+      response->mutable_data()->Resize((size_one < 0) ? size_two : size_one + 1, 0);
+      int32* data = reinterpret_cast<int32*>(response->mutable_data()->mutable_data());
+      auto status = library_->IotaWithCustomSize(size_one, size_two, data);
+      response->set_status(status);
+      if (status == 0) {
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeNonIviService::OutputArraysWithNarrowIntegerTypes(::grpc::ServerContext* context, const OutputArraysWithNarrowIntegerTypesRequest* request, OutputArraysWithNarrowIntegerTypesResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.h
@@ -32,6 +32,7 @@ public:
   ::grpc::Status Init(::grpc::ServerContext* context, const InitRequest* request, InitResponse* response) override;
   ::grpc::Status InitWithHandleNameAsSessionName(::grpc::ServerContext* context, const InitWithHandleNameAsSessionNameRequest* request, InitWithHandleNameAsSessionNameResponse* response) override;
   ::grpc::Status InputArraysWithNarrowIntegerTypes(::grpc::ServerContext* context, const InputArraysWithNarrowIntegerTypesRequest* request, InputArraysWithNarrowIntegerTypesResponse* response) override;
+  ::grpc::Status IotaWithCustomSize(::grpc::ServerContext* context, const IotaWithCustomSizeRequest* request, IotaWithCustomSizeResponse* response) override;
   ::grpc::Status OutputArraysWithNarrowIntegerTypes(::grpc::ServerContext* context, const OutputArraysWithNarrowIntegerTypesRequest* request, OutputArraysWithNarrowIntegerTypesResponse* response) override;
   ::grpc::Status InputArrayOfBytes(::grpc::ServerContext* context, const InputArrayOfBytesRequest* request, InputArrayOfBytesResponse* response) override;
   ::grpc::Status OutputArrayOfBytes(::grpc::ServerContext* context, const OutputArrayOfBytesRequest* request, OutputArrayOfBytesResponse* response) override;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -47,7 +47,7 @@ def is_unsupported_parameter(parameter):
       or is_unsupported_scalar_array(parameter)
 
 def is_unsupported_size_mechanism(parameter):
-  return not get_size_mechanism(parameter) in {'fixed', 'len', 'ivi-dance', 'passed-in', 'ivi-dance-with-a-twist', None}
+  return not get_size_mechanism(parameter) in {'fixed', 'len', 'ivi-dance', 'passed-in', 'ivi-dance-with-a-twist', 'custom-code', None}
 
 def is_unsupported_scalar_array(parameter):
   return is_array(parameter['type']) and is_unsupported_enum_array(parameter)

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -53,6 +53,50 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'CalculateReversePolyCoeff': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'forwardCoeffs',
+                'type': 'const float64[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'numForwardCoeffsIn',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'in',
+                'name': 'minValX',
+                'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'name': 'maxValX',
+                'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'name': 'numPointsToCompute',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'reversePolyOrder',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'reverseCoeffs',
+                'size': {
+                    'mechanism': 'custom-code',
+                    'value': '(reversePolyOrder < 0) ? numForwardCoeffsIn : reversePolyOrder + 1'
+                },
+                'type': 'float64[]'
+            }
+        ],
+        'returns': 'int32'
+    },
     'CfgAnlgEdgeRefTrig': {
         'parameters': [
             {

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -6888,6 +6888,57 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'ReadRaw': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'numSampsPerChan',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'readArray',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'arraySizeInBytes'
+                },
+                'type': 'uInt8[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySizeInBytes',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'sampsRead',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'numBytesPerSamp',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'include_in_proto': False,
+                'name': 'reserved',
+                'pass_null': True,
+                'type': 'bool32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'RegisterDoneEvent': {
         'codegen_method': 'CustomCode',
         'parameters': [
@@ -7884,6 +7935,48 @@ functions = {
                 'enum': 'GroupBy',
                 'name': 'dataLayout',
                 'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'writeArray',
+                'type': 'const uInt8[]'
+            },
+            {
+                'direction': 'out',
+                'name': 'sampsPerChanWritten',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'include_in_proto': False,
+                'name': 'reserved',
+                'pass_null': True,
+                'type': 'bool32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'WriteRaw': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'numSamps',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'autoStart',
+                'type': 'bool32'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
             },
             {
                 'direction': 'in',

--- a/source/codegen/metadata/nifake_non_ivi/functions.py
+++ b/source/codegen/metadata/nifake_non_ivi/functions.py
@@ -67,6 +67,30 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'IotaWithCustomSize': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'sizeOne',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'sizeTwo',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'data',
+                'size': {
+                    'mechanism': 'custom-code',
+                    'value': '(sizeOne < 0) ? sizeTwo : sizeOne + 1'
+                },
+                'type': 'int32[]'
+            },
+        ],
+        'returns': 'int32'
+    },
     'OutputArraysWithNarrowIntegerTypes': {
         'parameters': [
             {

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -410,6 +410,27 @@ class NiDAQmxDriverApiTests : public Test {
     return stub()->CreateAIThrmcplChan(&context, request, &response);
   }
 
+  CalculateReversePolyCoeffRequest create_calculate_reverse_poly_coeff_request(
+    const std::vector<double> forward_coeffs,
+    double min_val_x,
+    double max_val_x,
+    int32_t num_points_to_compute,
+    int32_t reverse_poly_order)
+  {
+    CalculateReversePolyCoeffRequest request;
+    request.mutable_forward_coeffs()->CopyFrom({forward_coeffs.cbegin(), forward_coeffs.cend()});
+    request.set_num_forward_coeffs_in(forward_coeffs.size());
+    request.set_min_val_x(min_val_x);
+    request.set_max_val_x(max_val_x);
+    request.set_num_points_to_compute(num_points_to_compute);
+    request.set_reverse_poly_order(reverse_poly_order);
+    return request;
+  }
+  ::grpc::Status calculate_reverse_poly_coeff(const CalculateReversePolyCoeffRequest& request, CalculateReversePolyCoeffResponse& response)  {
+    ::grpc::ClientContext context;
+    return stub()->CalculateReversePolyCoeff(&context, request, &response);
+  }
+
   std::unique_ptr<NiDAQmx::Stub>& stub()
   {
     return nidaqmx_stub_;
@@ -753,6 +774,38 @@ TEST_F(NiDAQmxDriverApiTests, SelfTestDevice_Succeeds)
   auto status = self_test_device(response);
 
   EXPECT_SUCCESS(status, response);
+}
+
+TEST_F(NiDAQmxDriverApiTests, CalculateReversePolyCoefficientsWithNegativeOneReverseOrder_ReturnsCoefficientsSizedToForwardCoefficients) {
+  auto const FORWARD_COEFFICIENTS = std::vector<double>{1.0, 3.0, 8.0};
+  auto const REVERSE_ORDER = -1;
+  auto request = create_calculate_reverse_poly_coeff_request(
+    FORWARD_COEFFICIENTS,
+    0.0,
+    10.0,
+    100,
+    REVERSE_ORDER);
+  auto response = CalculateReversePolyCoeffResponse{};
+  auto status = calculate_reverse_poly_coeff(request, response);
+
+  EXPECT_SUCCESS(status, response);
+  EXPECT_EQ(FORWARD_COEFFICIENTS.size(), response.reverse_coeffs().size());
+}
+
+
+TEST_F(NiDAQmxDriverApiTests, CalculateReversePolyCoefficientsWithPositiveReverseOrder_ReturnsCoefficientsSizedToReverseOrderPlusOne) {
+  auto const REVERSE_ORDER = 10;
+  auto request = create_calculate_reverse_poly_coeff_request(
+    {1.0, 3.0, 8.0},
+    0.0,
+    10.0,
+    100,
+    REVERSE_ORDER);
+  auto response = CalculateReversePolyCoeffResponse{};
+  auto status = calculate_reverse_poly_coeff(request, response);
+
+  EXPECT_SUCCESS(status, response);
+  EXPECT_EQ(REVERSE_ORDER + 1, response.reverse_coeffs().size());
 }
 }  // namespace system
 }  // namespace tests

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -5,6 +5,7 @@
 #include <server/session_resource_repository.h>
 
 #include <iostream>
+#include <numeric>
 #include <string>
 
 using namespace nifake_non_ivi_grpc;
@@ -128,6 +129,25 @@ class NiFakeNonIviServiceTests : public ::testing::Test {
     service_.Close(&context, &request, &response);
 
     return response.status();
+  }
+
+  void setup_iota_with_custom_size() {
+    auto set_iota_data = [](int32 size_one, int32 size_two, int32* data) {
+      auto out_size = (size_one == -1) ? size_two : size_one + 1;
+      std::iota(data, data + out_size, 0);
+    };
+
+    EXPECT_CALL(library_, IotaWithCustomSize(_, _, _))
+        .WillOnce(DoAll(
+            Invoke(set_iota_data),
+            Return(kDriverSuccess)));
+  }
+
+  static void EXPECT_IOTA_OF_SIZE(IotaWithCustomSizeResponse response, size_t size) {
+    std::vector<int32> expected(size);
+    std::iota(expected.begin(), expected.end(), 0);
+    std::vector<int32> actual{response.data().cbegin(), response.data().cend()};
+    EXPECT_THAT(actual, ContainerEq(expected));
   }
 };
 
@@ -382,6 +402,37 @@ TEST_F(NiFakeNonIviServiceTests, OutputArrayOfBytes)
   EXPECT_EQ(16, (myUInt8)response.u8_data()[2]);
   auto status = response.status();
   EXPECT_EQ(kDriverSuccess, status);
+}
+
+TEST_F(NiFakeNonIviServiceTests, IotaWithCustomSizeUsingFirstSizeOption_ReturnsIotaDataOfFirstSizePlusOne)
+{
+  const auto SIZE_ONE = 10;
+  setup_iota_with_custom_size();
+  ::grpc::ServerContext context;
+  IotaWithCustomSizeRequest request;
+  request.set_size_one(SIZE_ONE);
+  request.set_size_two(100000);
+  IotaWithCustomSizeResponse response;
+  service_.IotaWithCustomSize(&context, &request, &response);
+
+  EXPECT_EQ(kDriverSuccess, response.status());
+  EXPECT_IOTA_OF_SIZE(response, SIZE_ONE + 1);
+}
+
+TEST_F(NiFakeNonIviServiceTests, IotaWithCustomSizeUsingSecondSizeOption_ReturnsIotaDataOfSecondSize)
+{
+  const auto SIZE_TWO = 20;
+  setup_iota_with_custom_size();
+  ::grpc::ServerContext context;
+  IotaWithCustomSizeRequest request;
+  request.set_size_one(-1);
+  request.set_size_two(SIZE_TWO);
+  IotaWithCustomSizeResponse response;
+
+  service_.IotaWithCustomSize(&context, &request, &response);
+
+  EXPECT_EQ(kDriverSuccess, response.status());
+  EXPECT_IOTA_OF_SIZE(response, SIZE_TWO);
 }
 
 ACTION(ImmediatelyCallCallback)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add ReadRaw and WriteRaw to DAQ API.
The C API version of these methods uses `void *`s. Those are replaces with `repeated byte` in the grpc implementation.

### Why should this Pull Request be merged?

Incremental progress on grpc DAQ support.

### What testing has been done?

Ran and passed all DAQ tests.