### PR TITLE
In progress change for IpStackRef_t

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -20,6 +20,8 @@ service NiXnetSocket {
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc GetLastErrorNum(GetLastErrorNumRequest) returns (GetLastErrorNumResponse);
   rpc GetLastErrorStr(GetLastErrorStrRequest) returns (GetLastErrorStrResponse);
+  rpc IpStackClear(IpStackClearRequest) returns (IpStackClearResponse);
+  rpc IpStackCreate(IpStackCreateRequest) returns (IpStackCreateResponse);
   rpc Socket(SocketRequest) returns (SocketResponse);
 }
 
@@ -79,11 +81,31 @@ message GetLastErrorStrResponse {
   string error = 2;
 }
 
+message IpStackClearRequest {
+  nidevice_grpc.Session stack_ref = 1;
+}
+
+message IpStackClearResponse {
+  int32 status = 1;
+}
+
+message IpStackCreateRequest {
+  string session_name = 1;
+  string stack_name = 2;
+  string config = 3;
+}
+
+message IpStackCreateResponse {
+  int32 status = 1;
+  nidevice_grpc.Session stack_ref = 2;
+}
+
 message SocketRequest {
   string session_name = 1;
-  int32 domain = 2;
-  int32 type = 3;
-  int32 prototcol = 4;
+  nidevice_grpc.Session stack_ref = 2;
+  int32 domain = 3;
+  int32 type = 4;
+  int32 prototcol = 5;
 }
 
 message SocketResponse {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -81,12 +81,46 @@ get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len)
   return response;
 }
 
+IpStackClearResponse
+ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref)
+{
+  ::grpc::ClientContext context;
+
+  auto request = IpStackClearRequest{};
+  request.mutable_stack_ref()->CopyFrom(stack_ref);
+
+  auto response = IpStackClearResponse{};
+
+  raise_if_error(
+      stub->IpStackClear(&context, request, &response));
+
+  return response;
+}
+
+IpStackCreateResponse
+ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::string& config)
+{
+  ::grpc::ClientContext context;
+
+  auto request = IpStackCreateRequest{};
+  request.set_stack_name(stack_name);
+  request.set_config(config);
+
+  auto response = IpStackCreateResponse{};
+
+  raise_if_error(
+      stub->IpStackCreate(&context, request, &response));
+
+  return response;
+}
+
 SocketResponse
-socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol)
+socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol)
 {
   ::grpc::ClientContext context;
 
   auto request = SocketRequest{};
+  request.mutable_stack_ref()->CopyFrom(stack_ref);
   request.set_domain(domain);
   request.set_type(type);
   request.set_prototcol(prototcol);

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -26,7 +26,9 @@ BindResponse bind(const StubPtr& stub, const nidevice_grpc::Session& socket, con
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
 GetLastErrorNumResponse get_last_error_num(const StubPtr& stub);
 GetLastErrorStrResponse get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len);
-SocketResponse socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);
+IpStackClearResponse ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref);
+IpStackCreateResponse ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::string& config);
+SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);
 
 } // namespace nixnetsocket_grpc::experimental::client
 

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -25,6 +25,8 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("nxclose"));
   function_pointers_.GetLastErrorNum = reinterpret_cast<GetLastErrorNumPtr>(shared_library_.get_function_pointer("nxgetlasterrornum"));
   function_pointers_.GetLastErrorStr = reinterpret_cast<GetLastErrorStrPtr>(shared_library_.get_function_pointer("nxgetlasterrorstr"));
+  function_pointers_.IpStackClear = reinterpret_cast<IpStackClearPtr>(shared_library_.get_function_pointer("nxIpStackClear"));
+  function_pointers_.IpStackCreate = reinterpret_cast<IpStackCreatePtr>(shared_library_.get_function_pointer("nxIpStackCreate"));
   function_pointers_.Socket = reinterpret_cast<SocketPtr>(shared_library_.get_function_pointer("nxsocket"));
 }
 
@@ -84,6 +86,30 @@ char* NiXnetSocketLibrary::GetLastErrorStr(char buf[], size_t bufLen)
   return nxgetlasterrorstr(buf, bufLen);
 #else
   return function_pointers_.GetLastErrorStr(buf, bufLen);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::IpStackClear(nxIpStackRef_t stack_ref)
+{
+  if (!function_pointers_.IpStackClear) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxIpStackClear.");
+  }
+#if defined(_MSC_VER)
+  return nxIpStackClear(stack_ref);
+#else
+  return function_pointers_.IpStackClear(stack_ref);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::IpStackCreate(char stack_name[], char config[], nxIpStackRef_t* stack_ref)
+{
+  if (!function_pointers_.IpStackCreate) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxIpStackCreate.");
+  }
+#if defined(_MSC_VER)
+  return nxIpStackCreate(stack_name, config, stack_ref);
+#else
+  return function_pointers_.IpStackCreate(stack_name, config, stack_ref);
 #endif
 }
 

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -22,6 +22,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Close(nxSOCKET socket);
   int32_t GetLastErrorNum();
   char* GetLastErrorStr(char buf[], size_t bufLen);
+  int32_t IpStackClear(nxIpStackRef_t stack_ref);
+  int32_t IpStackCreate(char stack_name[], char config[], nxIpStackRef_t* stack_ref);
   nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol);
 
  private:
@@ -29,6 +31,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using ClosePtr = decltype(&nxclose);
   using GetLastErrorNumPtr = decltype(&nxgetlasterrornum);
   using GetLastErrorStrPtr = decltype(&nxgetlasterrorstr);
+  using IpStackClearPtr = decltype(&nxIpStackClear);
+  using IpStackCreatePtr = decltype(&nxIpStackCreate);
   using SocketPtr = decltype(&nxsocket);
 
   typedef struct FunctionPointers {
@@ -36,6 +40,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     ClosePtr Close;
     GetLastErrorNumPtr GetLastErrorNum;
     GetLastErrorStrPtr GetLastErrorStr;
+    IpStackClearPtr IpStackClear;
+    IpStackCreatePtr IpStackCreate;
     SocketPtr Socket;
   } FunctionLoadStatus;
 

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -19,6 +19,8 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Close(nxSOCKET socket) = 0;
   virtual int32_t GetLastErrorNum() = 0;
   virtual char* GetLastErrorStr(char buf[], size_t bufLen) = 0;
+  virtual int32_t IpStackClear(nxIpStackRef_t stack_ref) = 0;
+  virtual int32_t IpStackCreate(char stack_name[], char config[], nxIpStackRef_t* stack_ref) = 0;
   virtual nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol) = 0;
 };
 

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -21,6 +21,8 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Close, (nxSOCKET socket), (override));
   MOCK_METHOD(int32_t, GetLastErrorNum, (), (override));
   MOCK_METHOD(char*, GetLastErrorStr, (char buf[], size_t bufLen), (override));
+  MOCK_METHOD(int32_t, IpStackClear, (nxIpStackRef_t stack_ref), (override));
+  MOCK_METHOD(int32_t, IpStackCreate, (char stack_name[], char config[], nxIpStackRef_t* stack_ref), (override));
   MOCK_METHOD(nxSOCKET, Socket, (nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol), (override));
 };
 

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -24,9 +24,11 @@ namespace nixnetsocket_grpc {
   NiXnetSocketService::NiXnetSocketService(
       NiXnetSocketLibraryInterface* library,
       ResourceRepositorySharedPtr resource_repository,
+      nxIpStackRef_tResourceRepositorySharedPtr nx_ip_stack_ref_t_resource_repository,
       const NiXnetSocketFeatureToggles& feature_toggles)
       : library_(library),
       session_repository_(resource_repository),
+      nx_ip_stack_ref_t_resource_repository_(nx_ip_stack_ref_t_resource_repository),
       feature_toggles_(feature_toggles)
   {
   }
@@ -128,13 +130,65 @@ namespace nixnetsocket_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::IpStackClear(::grpc::ServerContext* context, const IpStackClearRequest* request, IpStackClearResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto stack_ref_grpc_session = request->stack_ref();
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nx_ip_stack_ref_t_resource_repository_->remove_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      auto status = library_->IpStackClear(stack_ref);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::IpStackCreate(::grpc::ServerContext* context, const IpStackCreateRequest* request, IpStackCreateResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      char* stack_name = (char*)request->stack_name().c_str();
+      char* config = (char*)request->config().c_str();
+
+      auto init_lambda = [&] () {
+        nxIpStackRef_t stack_ref;
+        auto status = library_->IpStackCreate(stack_name, config, &stack_ref);
+        return std::make_tuple(status, stack_ref);
+      };
+      uint32_t session_id = 0;
+      const std::string& grpc_device_session_name = request->session_name();
+      auto cleanup_lambda = [&] (nxIpStackRef_t id) { library_->IpStackClear(id); };
+      int status = nx_ip_stack_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      response->set_status(status);
+      if (status_ok(status)) {
+        response->mutable_stack_ref()->set_id(session_id);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiXnetSocketService::Socket(::grpc::ServerContext* context, const SocketRequest* request, SocketResponse* response)
   {
     if (context->IsCancelled()) {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      auto stack_ref = nullptr;
+      auto stack_ref_grpc_session = request->stack_ref();
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
       int32_t domain = request->domain();
       int32_t type = request->type();
       int32_t prototcol = request->prototcol();

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -34,10 +34,12 @@ struct NiXnetSocketFeatureToggles
 class NiXnetSocketService final : public NiXnetSocket::Service {
 public:
   using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>;
+  using nxIpStackRef_tResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>;
 
   NiXnetSocketService(
     NiXnetSocketLibraryInterface* library,
     ResourceRepositorySharedPtr resource_repository,
+    nxIpStackRef_tResourceRepositorySharedPtr nx_ip_stack_ref_t_resource_repository,
     const NiXnetSocketFeatureToggles& feature_toggles = {});
   virtual ~NiXnetSocketService();
   
@@ -45,10 +47,13 @@ public:
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status GetLastErrorNum(::grpc::ServerContext* context, const GetLastErrorNumRequest* request, GetLastErrorNumResponse* response) override;
   ::grpc::Status GetLastErrorStr(::grpc::ServerContext* context, const GetLastErrorStrRequest* request, GetLastErrorStrResponse* response) override;
+  ::grpc::Status IpStackClear(::grpc::ServerContext* context, const IpStackClearRequest* request, IpStackClearResponse* response) override;
+  ::grpc::Status IpStackCreate(::grpc::ServerContext* context, const IpStackCreateRequest* request, IpStackCreateResponse* response) override;
   ::grpc::Status Socket(::grpc::ServerContext* context, const SocketRequest* request, SocketResponse* response) override;
 private:
   NiXnetSocketLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
+  nxIpStackRef_tResourceRepositorySharedPtr nx_ip_stack_ref_t_resource_repository_;
 
   NiXnetSocketFeatureToggles feature_toggles_;
 };

--- a/generated/nixnetsocket/nixnetsocket_service_registrar.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service_registrar.cpp
@@ -17,11 +17,13 @@ namespace {
 struct LibraryAndService {
   LibraryAndService(
     const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>& resource_repository,
+    const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>& nx_ip_stack_ref_t_resource_repository,
     const NiXnetSocketFeatureToggles& feature_toggles) 
       : library(), 
       service(
         &library, 
         resource_repository,
+        nx_ip_stack_ref_t_resource_repository,
         feature_toggles) {
   }
   NiXnetSocketLibrary library;
@@ -32,6 +34,7 @@ struct LibraryAndService {
 std::shared_ptr<void> register_service(
   grpc::ServerBuilder& builder, 
   const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>& resource_repository,
+  const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>& nx_ip_stack_ref_t_resource_repository,
   const nidevice_grpc::FeatureToggles& feature_toggles)
 {
   auto toggles = NiXnetSocketFeatureToggles(feature_toggles);
@@ -40,6 +43,7 @@ std::shared_ptr<void> register_service(
   {
     auto library_and_service_ptr = std::make_shared<LibraryAndService>(
       resource_repository,
+      nx_ip_stack_ref_t_resource_repository,
       toggles);
     auto& service = library_and_service_ptr->service;
     builder.RegisterService(&service);

--- a/generated/nixnetsocket/nixnetsocket_service_registrar.h
+++ b/generated/nixnetsocket/nixnetsocket_service_registrar.h
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-#include <nxsocket.h> // for nxSOCKET
+#include <nxsocket.h> // for nxSOCKET, nxIpStackRef_t
 
 namespace grpc {
 class ServerBuilder;
@@ -23,6 +23,7 @@ using CodeReadiness = nidevice_grpc::FeatureToggles::CodeReadiness;
 std::shared_ptr<void> register_service(
   grpc::ServerBuilder& server_builder, 
   const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>& resource_repository,
+  const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>& nx_ip_stack_ref_t_resource_repository,
   const nidevice_grpc::FeatureToggles& feature_toggles);
 
 } // nixnetsocket_grpc

--- a/generated/register_all_services.cpp
+++ b/generated/register_all_services.cpp
@@ -65,6 +65,7 @@ std::shared_ptr<void> register_all_services(
   auto nx_session_ref_t_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<nxSessionRef_t>>(session_repository.get());
   auto nx_database_ref_t_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<nxDatabaseRef_t>>(session_repository.get());
   auto nx_socket_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<nxSOCKET>>(session_repository.get());
+  auto nx_ip_stack_ref_t_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>(session_repository.get());
 
   service_vector->push_back(
     nidaqmx_grpc::register_service(
@@ -179,6 +180,7 @@ std::shared_ptr<void> register_all_services(
     nixnetsocket_grpc::register_service(
       server_builder, 
       nx_socket_repository,
+      nx_ip_stack_ref_t_repository,
       feature_toggles));
 
   return service_vector;

--- a/source/codegen/metadata/nixnetsocket/config.py
+++ b/source/codegen/metadata/nixnetsocket/config.py
@@ -29,7 +29,7 @@ config = {
     'extra_errors_used': [
     ],
     'init_function': 'Socket',
-    'resource_handle_type': 'nxSOCKET',
+    'resource_handle_type': ['nxSOCKET', 'nxIpStackRef_t'],
     'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -69,6 +69,39 @@ functions = {
         ],
         'returns': 'char*'
     },
+    'IpStackClear': {
+        'custom_close_method': True,
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'stack_ref',
+                'type': 'nxIpStackRef_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
+    'IpStackCreate': {
+        'custom_close': 'IpStackClear(id)',
+        'init_method': True,
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'stack_name',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'config',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'out',
+                'name': 'stack_ref',
+                'type': 'nxIpStackRef_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
     'Socket': {
         'cname': 'nxsocket',
         'init_method': True,
@@ -76,8 +109,6 @@ functions = {
         'parameters': [
             {
                 'direction': 'in',
-                'hardcoded_value': 'nullptr',
-                'include_in_proto': False,
                 'name': 'stack_ref',
                 'type': 'nxIpStackRef_t'
             },
@@ -98,7 +129,6 @@ functions = {
             },
             {
                 'direction': 'out',
-                'grpc_type': 'nidevice_grpc.Session',
                 'name': 'socket',
                 'return_value': True,
                 'type': 'nxSOCKET'

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -3,12 +3,17 @@
 #include <gtest/gtest.h>
 #include <nixnetsocket/nixnetsocket_client.h>
 
+#include <iostream>
+#include <nlohmann/json.hpp>
+
 #include "device_server.h"
+#include "enumerate_devices.h"
 
 using namespace nixnetsocket_grpc;
 namespace client = nixnetsocket_grpc::experimental::client;
 namespace pb = google::protobuf;
 using namespace ::testing;
+using nlohmann::json;
 
 namespace ni {
 namespace tests {
@@ -19,14 +24,8 @@ constexpr auto INVALID_XNET_SOCKET = -1;
 constexpr auto GENERIC_NXSOCKET_ERROR = -1;
 constexpr auto SOCKET_COULD_NOT_BE_FOUND = -13009;
 constexpr auto SOCKET_COULD_NOT_BE_FOUND_MESSAGE = "The specified socket could not be found.";
-
-constexpr auto SIMPLE_CONFIG_JSON = R"(
-{
-  "schema": "file:///NIXNET_Documentation/xnetIpStackSchema-03.json",
-  "xnetInterfaces": [
-    {
-      "name": "ENET1",
-      "MACs": [
+constexpr auto SCHEMA = "file:///NIXNET_Documentation/xnetIpStackSchema-03.json";
+const auto SIMPLE_INTERFACE_CONFIG = R"(      
         {
           "address": "inherit",
           "VLANs": [
@@ -43,20 +42,48 @@ constexpr auto SIMPLE_CONFIG_JSON = R"(
             }
           ]
         }
-      ]
-    }
-  ]
-})";
+)"_json;
 
-class NiXnetDriverApiTests : public ::testing::Test {
+std::string create_simple_config(const std::string& interface_name)
+{
+  auto interface_config = json{};
+  interface_config["name"] = interface_name;
+  interface_config["MACs"] = std::vector<json>{SIMPLE_INTERFACE_CONFIG};
+
+  auto config = json{};
+  config["schema"] = SCHEMA;
+  config["xnetInterfaces"] = std::vector<json>{interface_config};
+
+  return config.dump();
+}
+
+class NiXnetSocketDriverApiTests : public ::testing::Test {
  protected:
-  NiXnetDriverApiTests()
+  NiXnetSocketDriverApiTests()
       : device_server_(DeviceServerInterface::Singleton()),
         stub_(NiXnetSocket::NewStub(device_server_->InProcessChannel()))
   {
     device_server_->ResetServer();
   }
-  virtual ~NiXnetDriverApiTests() {}
+  virtual ~NiXnetSocketDriverApiTests() {}
+
+  void SetUp() override
+  {
+    const auto discovered_devices = EnumerateDevices();
+
+    for (const auto& required_name : required_interfaces()) {
+      auto found = std::find_if(
+          discovered_devices.cbegin(),
+          discovered_devices.cend(),
+          [&required_name](const nidevice_grpc::DeviceProperties& properties) {
+            return properties.name() == required_name;
+          });
+
+      if (found == discovered_devices.cend()) {
+        GTEST_SKIP() << "Interface not found: " << required_name;
+      }
+    }
+  }
 
   void TearDown() override
   {
@@ -74,9 +101,25 @@ class NiXnetDriverApiTests : public ::testing::Test {
     return stub_;
   }
 
+  virtual std::vector<std::string> required_interfaces() const = 0;
+
  private:
   DeviceServerInterface* device_server_;
   std::unique_ptr<NiXnetSocket::Stub> stub_;
+};
+
+class NiXnetSocketLoopbackTests : public NiXnetSocketDriverApiTests {
+  virtual std::vector<std::string> required_interfaces() const override
+  {
+    return {"ENET1,ENET2,ENET3,ENET4"};
+  }
+};
+
+class NiXnetSocketNoHardwareTests : public NiXnetSocketDriverApiTests {
+  virtual std::vector<std::string> required_interfaces() const override
+  {
+    return {};
+  }
 };
 
 #define EXPECT_SUCCESS(response)       \
@@ -89,7 +132,8 @@ class NiXnetDriverApiTests : public ::testing::Test {
     EXPECT_EQ(error, (response).status()); \
   }
 
-SocketResponse socket(client::StubPtr& stub, const nidevice_grpc::Session& stack)
+SocketResponse
+socket(client::StubPtr& stub, const nidevice_grpc::Session& stack)
 {
   return client::socket(stub, stack, 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
 }
@@ -99,7 +143,7 @@ SocketResponse socket(client::StubPtr& stub)
   return socket(stub, nidevice_grpc::Session{});
 }
 
-TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Close_ReturnsAndSetsExpectedErrors)
+TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Close_ReturnsAndSetsExpectedErrors)
 {
   auto socket_response = socket(stub());
   auto socket_get_last_error = client::get_last_error_num(stub());
@@ -119,7 +163,7 @@ TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Close_ReturnsAndSetsExpected
   EXPECT_THAT("The specified socket could not be found.", close_get_last_error_str.error());
 }
 
-TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsExpectedErrors)
+TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsExpectedErrors)
 {
   auto sock_addr = SockAddr{};
   sock_addr.mutable_ipv4()->set_addr(0x7F000001);
@@ -135,28 +179,44 @@ TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsExpectedE
   EXPECT_THAT(SOCKET_COULD_NOT_BE_FOUND_MESSAGE, bind_get_last_error_str.error());
 }
 
-TEST_F(NiXnetDriverApiTests, InvalidEmptyConfigJson_IpStackCreate_ReturnsInvalidInterfaceNameError)
+TEST_F(NiXnetSocketNoHardwareTests, InvalidEmptyConfigJson_IpStackCreate_ReturnsInvalidInterfaceNameError)
 {
   constexpr auto TEST_CONFIG = "{}";
-  constexpr auto FAILED_TO_CREATE_STACK = -13107;
+  constexpr auto JSON_OBJECT_MISSING_VALUE = -13017;
   const auto stack_response = client::ip_stack_create(stub(), "test", "{}");
-  auto get_last_error_str = client::get_last_error_str(stub(), 512);
 
-  EXPECT_XNET_ERROR(FAILED_TO_CREATE_STACK, stack_response);
-  EXPECT_THAT(get_last_error_str.error(), IsEmpty());
+  EXPECT_XNET_ERROR(JSON_OBJECT_MISSING_VALUE, stack_response);
 }
 
-TEST_F(NiXnetDriverApiTests, ValidConfigJsonForMissingDevice_IpStackCreate_ReturnsInvalidInterfaceNameError)
+TEST_F(NiXnetSocketNoHardwareTests, ValidConfigJsonForMissingDevice_IpStackCreate_ReturnsInvalidInterfaceNameError)
 {
-  constexpr auto EST_CONFIG = SIMPLE_CONFIG_JSON;
-  constexpr auto FAILED_TO_CREATE_STACK = -13107;
-  constexpr auto JSON_MISSING_VALUE = (int32_t)0xFFFFCD27;
+  const auto TEST_CONFIG = create_simple_config("ENET6");
   constexpr auto INVALID_INTERFACE_NAME = -1074384758;
-  const auto stack_response = client::ip_stack_create(stub(), "test", SIMPLE_CONFIG_JSON);
-  auto get_last_error_str = client::get_last_error_str(stub(), 512);
+  const auto stack_response = client::ip_stack_create(stub(), "test", TEST_CONFIG);
 
   EXPECT_XNET_ERROR(INVALID_INTERFACE_NAME, stack_response);
-  EXPECT_THAT(get_last_error_str.error(), HasSubstr("An object in the IP Stack configuration is missing a required member. Refer to the IP Stack configuration schema for the expected members."));
+}
+
+TEST_F(NiXnetSocketLoopbackTests, IpStackCreate_CreateSocketWithIpStack_Succeeds)
+{
+  const auto stack_response = client::ip_stack_create(stub(), "test", create_simple_config("ENET1"));
+
+  const auto socket_response = socket(stub(), stack_response.stack_ref());
+
+  EXPECT_SUCCESS(stack_response);
+  EXPECT_SUCCESS(socket_response);
+}
+
+TEST_F(NiXnetSocketLoopbackTests, IpStackCreateAndClear_CreateSocketWithIpStack_Fails)
+{
+  const auto create_stack_response = client::ip_stack_create(stub(), "test", create_simple_config("ENET1"));
+  const auto clear_stack_response = client::ip_stack_clear(stub(), create_stack_response.stack_ref());
+
+  const auto socket_response = socket(stub(), create_stack_response.stack_ref());
+
+  EXPECT_SUCCESS(create_stack_response);
+  EXPECT_SUCCESS(clear_stack_response);
+  EXPECT_XNET_ERROR(GENERIC_NXSOCKET_ERROR, socket_response);
 }
 
 }  // namespace


### PR DESCRIPTION
This is based off of @doshirohan's ni/grpc-device#572 and will be turned into a PR on grpc-device once that goes in.

Key features:
* Allows creation of a valid `nxSOCKET`.
* Demos working HW tests for creating `nxSOCKET` (works with hw I have set up at NIC).
* Demos writing a test class with tests that require HW, skip if HW is not present, and a separate set of tests that don't require hw.